### PR TITLE
Replace Restkit with Requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-restkit
+requests

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,10 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         "Topic :: Software Development :: Localization",
     ],
-    install_requires=['restkit'],
+    install_requires=['requests'],
     license='MIT',
     test_suite="nose.collector",
 )


### PR DESCRIPTION
Since Restkit is not compatible with Python 3, it is replaced with Requests.
Biggest change is the way a file is uploaded:
 - file is seperate argument
 - if you pass header, POEditor complains, without header it works